### PR TITLE
Simplify columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,3 @@ omit = [
   "*/__init__.py",  # Exclude all __init__.py files
   # Add other patterns if needed, e.g., "*/.venv/*", "*/tests/*", etc.
 ]
-

--- a/scripts/create_requirements.sh
+++ b/scripts/create_requirements.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create requirements.txt file
 uv export --no-hashes --format requirements-txt --all-groups > requirements_dev.txt

--- a/sweet_validation/columns/columns.py
+++ b/sweet_validation/columns/columns.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from copy import deepcopy
 from typing import Any
 
 from frictionless import Field, Report, Resource, Schema
@@ -15,17 +15,23 @@ class Column:
 
     Attributes:
         field (Field): A frictionless Field object.
-        items (list): A list of items. It can only modified during instantiation,
-            or by using the append, extend, or replace methods.
-        name (str): The name of the column defined in the field object. Read-only.
-            It can be modified via the field object.
-        description (str): The description of the column defined in the field object.
-            Read-only. It can be modified via the field object.
-        type (str): The type of the column defined in the field object. Read-only.
-            It can be modified via the field object.
+            The field object defines the type and constraints of the column.
+            It can only be modified during instantiation. Otherwise it is
+            immutable.
+        items (list): A list of items. The items are validated against the field object.
+            items are immutable and can only be set during instantiation or by
+            replacing the items (e.g., col.items = [1, 2, 3]) which triggers
+            a validation check.
+
+    Methods:
+        is_valid: Raise a ValidationError if the items are not valid. It can also
+            be used to validate a list of items against the Field object.
+        validate_items: Validate a list of items against the Field object.
+        get_resource: Return a frictionless Resource object with the column items.
 
     Raises:
         ValidationError: If the items are not valid given the Field object.
+        AttributeError: If the fields are modified after instantiation.
 
     The field object defines the type and constraints of the column and is based
     on the frictionless.Field object. The items are validated against this field
@@ -39,105 +45,62 @@ class Column:
 
     Examples:
 
-    ```python
-    from frictionless.fields import IntegerField
-    field=IntegerField(name="test", constraints={"minimum": 1, "maximum": 3})
-    col = Column(field=field, items=[1, 2, 3])
-    ```
+        ```python
+        from frictionless.fields import IntegerField
+        field = IntegerField(name="test", constraints={"minimum": 1, "maximum": 3})
+        col = Column(field=field, items=[1, 2, 3])
+        ```
+
+        The field property is immutable and items can only be replaced by a new list.
+        That means that you always receive a copy of items and fields and modifying
+        these copies will not affect the original column.
+
+        ```python
+        from frictionless.fields import IntegerField
+        field = IntegerField(name="test")
+        col = Column(field=field, items=[1, 2, 3])
+        print(col.items)  # returns [1, 2, 3]
+        new_items = col.items
+        new_items.append(4)
+        print(col.items)  # still returns [1, 2, 3]
+        col.items = new_items
+        print(col.items)  # returns [1, 2, 3, 4]
+        new_field = IntegerField(name="another_test") # raises AttributeError
+        ```
 
     """
 
     _items: list[Any]
+    _field: Field
 
     def __init__(self, field: Field, items: list[Any] | None = None):
-        self.field = field
+        self._field = field
         if items:
-            self._raise_on_validation(items=items)
+            self.is_valid(items=items)
         self._items = items or []
 
     @property
     def items(self) -> list[Any]:
         """Return the items of the column."""
-        return self._items
+        return deepcopy(self._items)
 
     @items.setter
     def items(self, items: list[Any]) -> None:
         """Set the items of the column."""
-        raise AttributeError("Cannot set the items of a column. Use append or extend")
-
-    @property
-    def name(self) -> Any:
-        """Return the name of the column defined in the field object"""
-        return self.field.name
-
-    @name.setter
-    def name(self, name: str) -> None:
-        raise AttributeError(
-            "Cannot set the name of a column. Set the name of the field object instead."
-        )
-
-    @property
-    def description(self) -> Any:
-        """Return the description of the column defined in the field object"""
-        return self.field.description
-
-    @description.setter
-    def description(self, description: str) -> None:
-        raise AttributeError(
-            "Cannot set the description of a column. Set the description of the field object instead."  # noqa
-        )
-
-    @property
-    def type(self) -> Any:
-        """Return the type of the column defined in the field object"""
-        return self.field.type
-
-    @type.setter
-    def type(self, type: str) -> None:
-        """Set the type of the column defined in the field object"""
-        raise AttributeError(
-            "Cannot set the type of a column. Set the type of the field object instead."
-        )
-
-    def append(self, item: Any) -> None:
-        """Append an item to the column items.
-
-        Args:
-            item (Any): An item to append to the column items.
-
-        Raises:
-            ValidationError: If the item is not valid.
-        """
-        new_items = self.items + [item]
-        self._raise_on_validation(items=new_items)
-        self._items = new_items
-
-    def extend(self, items: Iterable[Any]) -> None:
-        """Extend the column items with a list of items.
-
-        Args:
-            items (list): A list of items to extend the column items.
-
-        Raises:
-            ValidationError: If the items are not valid.
-        """
-        new_items = self.items + list(items)
-        self._raise_on_validation(items=new_items)
-        self._items = new_items
-
-    def replace(self, items: list[Any]) -> None:
-        """Replace the column items with a list of items.
-
-        Args:
-            items (list): A list of items to replace the column items.
-
-        Raises:
-            ValidationError: If the items are not valid.
-        """
-        self._raise_on_validation(items=items)
+        self.is_valid(items=items)
         self._items = items
 
-    def _raise_on_validation(self, items: list[Any] | None = None) -> None:
+    @property
+    def field(self) -> Field:
+        """Return the field object of the column."""
+        return self._field
+
+    @field.setter
+    def field(self, field: Field) -> None:
+        """Set the field object of the column."""
+        raise AttributeError("Cannot reset the field. Create a new column instead.")
+
+    def is_valid(self, items: list[Any] | None = None) -> None:
         """Raise a ValidationError if the items are not valid.
 
         Args:
@@ -171,7 +134,3 @@ class Column:
         items = items or self.items
         data = [[self.field.name]] + [[i] for i in items]
         return Resource(data=data, schema=Schema(fields=[self.field]))
-
-    def __len__(self) -> int:
-        """Returns the number of items"""
-        return len(self.items)

--- a/sweet_validation/columns/validated_items.py
+++ b/sweet_validation/columns/validated_items.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Any
+
+
+class ValidatedItems(ABC):
+    """Abstract class for class holding a list of items that are always validated
+    if changed.
+
+    Attributes:
+        items: A list of items that are validated.
+            Items are immutable and can only be replaced by reassigning the items
+            attribute which triggers the validation process.
+
+    Methods:
+        validate_items: Validate items
+        is_valid: Check if items are valid. It allows also allows for testing
+            an item object against the validation used in the class.
+    """
+
+    _items: Any
+
+    def __init__(self, items: Any):
+        if self.is_valid(items=items, raise_exception=True):
+            self._items = items
+
+    @property
+    def items(self) -> Any:
+        """Return the items of the column."""
+        return deepcopy(self._items)
+
+    @items.setter
+    def items(self, items: Any) -> None:
+        """Set the items of the column."""
+        self.is_valid(items=items, raise_exception=True)
+        self._items = items
+
+    @abstractmethod
+    def is_valid(self, items: Any, raise_exception: bool = True) -> bool:
+        """Raise a ValidationError if the items are not valid.
+
+        Args:
+            items (Any): A list of items. If None, the column items are used.
+            raise_exception (bool): If True, raise an error if the items
+                are not valid. If False returns False if validation fails.
+
+        Raises:
+            ValidationError: If the items are not valid. The validation error
+                should contain a report of the validation.
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def validate_items(self, items: Any) -> Any:
+        """Validate a list of items against the Field object.
+
+        Args:
+            items (Any): A list of items.
+
+        Returns:
+            Any: Should return a validation report.
+        """
+        raise NotImplementedError  # pragma: no cover

--- a/sweet_validation/tests/test_columns.py
+++ b/sweet_validation/tests/test_columns.py
@@ -44,3 +44,14 @@ def test_immutable_items():
     assert col.items == [1, 2, 3]
     col.items = new_items
     assert col.items == [1, 2, 3, 4]
+
+
+def test_is_valid():
+    field = IntegerField(name="test", constraints={"minimum": 1, "maximum": 3})
+    items = [1, 2, 3]
+    col = Column(field=field, items=items)
+    assert col.is_valid()
+    items = [0, 2, 3, 5]
+    with pytest.raises(ValidationError):
+        col.is_valid(items=items)
+    assert not col.is_valid(items=items, raise_exception=False)

--- a/sweet_validation/tests/test_columns.py
+++ b/sweet_validation/tests/test_columns.py
@@ -27,69 +27,20 @@ def test_init_constraints():
         _ = Column(field=field, items=items)
 
 
-def test_len():
+def test_immutable_field():
     field = IntegerField(name="test")
     items = [1, 2, 3]
     col = Column(field=field, items=items)
-    assert len(col) == 3
-    col.append(4)
-    assert len(col) == 4
+    with pytest.raises(AttributeError):
+        col.field = IntegerField(name="another_test")
 
 
-def test_expand():
+def test_immutable_items():
     field = IntegerField(name="test")
     items = [1, 2, 3]
     col = Column(field=field, items=items)
-    col.extend([4, 5, 6])
-    assert col.items == [1, 2, 3, 4, 5, 6]
-    with pytest.raises(ValidationError):
-        col.extend(["a", "b", "c"])
-
-
-def test_getattr():
-    field = IntegerField(name="test", description="A test column")
-    items = [1, 2, 3]
-    col = Column(field=field, items=items)
-    # attributes from the Field object
-    assert col.name == "test"
-    assert col.type == "integer"
-    assert col.description == "A test column"
-    # attributes from the Column object
-    assert col.items == items
-    assert col.field == field
-    with pytest.raises(AttributeError):
-        _ = col.not_an_attribute
-
-
-def test_set_attr():
-    field = IntegerField(name="test", description="A test column")
-    items = [1, 2, 3]
-    col = Column(field=field, items=items)
-    with pytest.raises(AttributeError):
-        col.name = "new_name"
-    with pytest.raises(AttributeError):
-        col.description = "new_description"
-    with pytest.raises(AttributeError):
-        col.type = "new_type"
-    with pytest.raises(AttributeError):
-        col.items = [1, 2, 3]
-
-
-def test_append():
-    field = IntegerField(name="test")
-    items = [1, 2, 3]
-    col = Column(field=field, items=items)
-    col.append(4)
+    new_items = col.items
+    new_items.append(4)
+    assert col.items == [1, 2, 3]
+    col.items = new_items
     assert col.items == [1, 2, 3, 4]
-    with pytest.raises(ValidationError):
-        col.append("a")
-
-
-def test_replace():
-    field = IntegerField(name="test")
-    items = [1, 2, 3]
-    col = Column(field=field, items=items)
-    col.replace([1, 2])
-    assert col.items == [1, 2]
-    with pytest.raises(ValidationError):
-        col.replace(["a"])


### PR DESCRIPTION
Simplified Column class to only return deep copies of field and items object. That avoids that they can be indirectly modified without validation.

Introduced ValidatedItems class. The class is (partly) abstract but implements that items can only be modified if valid.

Columns inherit from ValidatedItems.