### PR TITLE
Abstract registry storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,9 @@ omit = [
     "*/__init__.py",  # Exclude all __init__.py files
     # Add other patterns if needed, e.g., "*/.venv/*", "*/tests/*", etc.
 ]
-exclude_lines = [
+
+[tool.coverage.report]
+exclude_also = [
     'pragma: no cover',
     'except NotImplementedError:',
     'raise NotImplementedError',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ exclude = ["*/tests/"]
 
 [tool.coverage.run]
 omit = [
-  "*/__init__.py",  # Exclude all __init__.py files
-  # Add other patterns if needed, e.g., "*/.venv/*", "*/tests/*", etc.
+    "*/__init__.py",  # Exclude all __init__.py files
+    # Add other patterns if needed, e.g., "*/.venv/*", "*/tests/*", etc.
+]
+exclude_lines = [
+    'pragma: no cover',
+    'except NotImplementedError:',
+    'raise NotImplementedError',
+    'return NotImplemented'
 ]

--- a/sweet_validation/columns/__init__.py
+++ b/sweet_validation/columns/__init__.py
@@ -1,1 +1,0 @@
-from .columns import *  # noqa

--- a/sweet_validation/items/__init__.py
+++ b/sweet_validation/items/__init__.py
@@ -1,0 +1,2 @@
+from .columns import Column
+from .validated_values import ValidatedValues

--- a/sweet_validation/items/__init__.py
+++ b/sweet_validation/items/__init__.py
@@ -1,2 +1,4 @@
 from .columns import Column
 from .validated_values import ValidatedValues
+
+__all__ = ["Column", "ValidatedValues"]

--- a/sweet_validation/items/columns.py
+++ b/sweet_validation/items/columns.py
@@ -20,7 +20,7 @@ class Column(ValidatedValues[list[Any]]):
     - [Field types](https://framework.frictionlessdata.io/docs/fields/any.html)
         under "Data Fields"
     - [Constraints](https://specs.frictionlessdata.io/table-schema/#constraints)
-    - [Table and Field Scheme standard](https://specs.frictionlessdata.io/table-schema/#constraints)
+    - [Table and Field Scheme standard](https://datapackage.org/standard/table-schema/)
 
     Attributes:
         field (Field): A frictionless Field object.
@@ -68,7 +68,6 @@ class Column(ValidatedValues[list[Any]]):
         print(col.values)  # returns [1, 2, 3, 4]
         new_field = IntegerField(name="another_test") # raises AttributeError
         ```
-
     """
 
     _values: list[Any] = []

--- a/sweet_validation/items/validated_values.py
+++ b/sweet_validation/items/validated_values.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Protocol
 
 T = TypeVar("T")
 
-__all__ = ["ValidatedValues"]
+__all__ = ["ValidatedValues", "ValidatedValuesProtocol"]
 
 
 class ValidatedValues(ABC, Generic[T]):
@@ -65,3 +65,10 @@ class ValidatedValues(ABC, Generic[T]):
             Any: Should return a validation report.
         """
         raise NotImplementedError  # pragma: no cover
+
+
+class ValidatedValuesProtocol(Protocol):
+    @property
+    def values(self) -> Any: ...
+    def is_valid(self, value: Any) -> bool: ...
+    def validate(self, value: Any) -> Any: ...

--- a/sweet_validation/items/validated_values.py
+++ b/sweet_validation/items/validated_values.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Generic, TypeVar, Protocol
+from typing import Any, Generic, Protocol, TypeVar
 
 T = TypeVar("T")
 

--- a/sweet_validation/items/validated_values.py
+++ b/sweet_validation/items/validated_values.py
@@ -4,6 +4,8 @@ from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
 
+__all__ = ["ValidatedValues"]
+
 
 class ValidatedValues(ABC, Generic[T]):
     """Abstract class for class holding a value object that are always validated

--- a/sweet_validation/items/validated_values.py
+++ b/sweet_validation/items/validated_values.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
 
 T = TypeVar("T")
 
@@ -67,6 +67,7 @@ class ValidatedValues(ABC, Generic[T]):
         raise NotImplementedError  # pragma: no cover
 
 
+@runtime_checkable
 class ValidatedValuesProtocol(Protocol):
     @property
     def values(self) -> Any: ...

--- a/sweet_validation/registry/registry.py
+++ b/sweet_validation/registry/registry.py
@@ -1,0 +1,183 @@
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from frictionless import Schema
+
+from sweet_validation.items import ValidatedValues
+from sweet_validation.storage import Storage
+
+# Define a type variable for allowed schemas currently bound to only allow for
+# frictionless schemas
+AllowedSchema = TypeVar("AllowedSchema", bound=Schema)
+
+
+class Registry(ABC, Generic[AllowedSchema]):
+    """Abstract class for data registry
+
+    A registry provides access to data and schemas that describe the data and
+    can be used to validate the data. For this the registry uses two separate
+    storage backends, one for the data and one for the schemas. The registry
+    maintains the link between data and respective schemas and allows to get
+    data with the schema but also single columns together with their description.
+
+    The registry enforces a schema standard and currently we only support the
+    frictionless schema standard.
+
+    Attributes:
+        schema_storage (Storage): A storage backend for schemas.
+        data_storage (Storage): A storage backend for data.
+        schemas (list): A list of schema keys.
+
+    """
+
+    @property
+    @abstractmethod
+    def schemas(self) -> list[Any]:
+        """Return a list of schema keys."""
+
+    @property
+    @abstractmethod
+    def schema_storage(self) -> Storage:
+        """Return the schema storage backend."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def data_storage(self) -> Storage:
+        """Return the data storage backend."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_schema(self, key: Any) -> AllowedSchema:
+        """Return a schema object by key.
+
+        Args:
+            key (Any): The key of the schema.
+
+        Returns:
+            AllowedSchema: The schema object.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_schema(self, key: Any, schema: AllowedSchema) -> None:
+        """Save a schema object by key.
+
+        Args:
+            key (Any): The key of the schema.
+            schema (Schema): The schema object.
+
+        Raises:
+            KeyError: If the schema already exists.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_schema(self, key: Any) -> None:
+        """Delete a schema object by key.
+
+        Args:
+            key (Any): The key of the schema.
+
+        Raises:
+            KeyError: If the schema does not exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_schema(self, key: Any, schema: AllowedSchema) -> None:
+        """Update a schema object by key.
+
+        Note that updating a schema object must trigger a re-validation of all
+        data objects that are linked to this schema to ensure consistency.
+
+        Args:
+            key (Any): The key of the schema.
+            schema (AllowedSchema): The schema object.
+
+        Raises:
+            KeyError: If the schema does not exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_data(self, key: Any) -> ValidatedValues:
+        """Return a data object by key.
+
+        Args:
+            key (Any): The key of the data.
+
+        Returns:
+            ValidatedValues: The data object.
+
+        Raises:
+            KeyError: If the data does not exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_data(self, key: Any, data: ValidatedValues) -> None:
+        """Save a data object by key.
+
+        Args:
+            key (Any): The key of the data.
+            data (ValidatedValues): The data object.
+
+        Raises:
+            KeyError: If the data already exists.
+        """
+        raise NotImplementedError
+
+    def delete_data(self, key: Any) -> None:
+        """Delete a data object by key.
+
+        Args:
+            key (Any): The key of the data.
+
+        Raises:
+            KeyError: If the data does not exist.
+        """
+        raise NotImplementedError
+
+    def update_data(self, key: Any, data: ValidatedValues) -> None:
+        """Update a data object by key.
+
+        Args:
+            key (Any): The key of the data.
+            data (ValidatedValues): The data object.
+
+        Raises:
+            KeyError: If the data does not exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_column_data(self, data: Any, column: Any) -> ValidatedValues:
+        """Return a column object by key.
+
+        Args:
+            data (Any): The key of the data source object
+            column (Any): The key of the column.
+
+        Returns:
+            ValidatedValues: The column object.
+
+        Raises:
+            KeyError: If the column does not exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_data_schema(self, key: Any) -> AllowedSchema:
+        """Return the schema object for a data object by key.
+
+        Args:
+            key (Any): The key of the data.
+
+        Returns:
+            AllowedSchema: The schema object.
+
+        Raises:
+            KeyError: If the data does not exist.
+        """
+        raise NotImplementedError

--- a/sweet_validation/registry/registry.py
+++ b/sweet_validation/registry/registry.py
@@ -3,7 +3,7 @@ from typing import Any, Generic, TypeVar
 
 from frictionless import Schema
 
-from sweet_validation.items import ValidatedValues
+from sweet_validation.items.validated_values import ValidatedValues
 from sweet_validation.storage import Storage
 
 # Define a type variable for allowed schemas currently bound to only allow for

--- a/sweet_validation/registry/registry.py
+++ b/sweet_validation/registry/registry.py
@@ -3,7 +3,7 @@ from typing import Any, Generic, TypeVar
 
 from frictionless import Schema
 
-from sweet_validation.items.validated_values import ValidatedValues
+from sweet_validation.items.validated_values import ValidatedValuesProtocol
 from sweet_validation.storage import Storage
 
 # Define a type variable for allowed schemas currently bound to only allow for
@@ -101,7 +101,7 @@ class Registry(ABC, Generic[AllowedSchema]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_data(self, key: Any) -> ValidatedValues:
+    def get_data(self, key: Any) -> ValidatedValuesProtocol:
         """Return a data object by key.
 
         Args:
@@ -116,7 +116,7 @@ class Registry(ABC, Generic[AllowedSchema]):
         raise NotImplementedError
 
     @abstractmethod
-    def save_data(self, key: Any, data: ValidatedValues) -> None:
+    def save_data(self, key: Any, data: ValidatedValuesProtocol) -> None:
         """Save a data object by key.
 
         Args:
@@ -139,7 +139,7 @@ class Registry(ABC, Generic[AllowedSchema]):
         """
         raise NotImplementedError
 
-    def update_data(self, key: Any, data: ValidatedValues) -> None:
+    def update_data(self, key: Any, data: ValidatedValuesProtocol) -> None:
         """Update a data object by key.
 
         Args:
@@ -152,7 +152,7 @@ class Registry(ABC, Generic[AllowedSchema]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_column_data(self, data: Any, column: Any) -> ValidatedValues:
+    def get_column_data(self, data: Any, column: Any) -> ValidatedValuesProtocol:
         """Return a column object by key.
 
         Args:

--- a/sweet_validation/storage/__init__.py
+++ b/sweet_validation/storage/__init__.py
@@ -1,0 +1,1 @@
+from .storage import Storage

--- a/sweet_validation/storage/__init__.py
+++ b/sweet_validation/storage/__init__.py
@@ -1,1 +1,3 @@
 from .storage import Storage
+
+__all__ = ["Storage"]

--- a/sweet_validation/storage/storage.py
+++ b/sweet_validation/storage/storage.py
@@ -38,6 +38,6 @@ class Storage(ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def list(self):
+    def list(self) -> list[Any]:
         """List all keys in the storage backend."""
         raise NotImplementedError  # pragma: no cover

--- a/sweet_validation/storage/storage.py
+++ b/sweet_validation/storage/storage.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+__all__ = ["Storage"]
+
+
+class Storage(ABC):
+    """Abstract class for storage backends
+
+    Storage backends implement at the very least the following methods:
+
+    Methods:
+        save: Save a value to the storage backend.
+        load: Load a value from the storage backend.
+        delete: Delete a value from the storage backend.
+        exists: Check if a value exists in the storage backend.
+        list: List all keys in the storage backend.
+    """
+
+    @abstractmethod
+    def save(self, key: Any, value: Any) -> None:
+        """Save a value to the storage backend."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def load(self, key: Any) -> Any:
+        """Load a value from the storage backend."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def delete(self, key: Any) -> Any:
+        """Delete a value from the storage backend."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def exists(self, key: Any) -> bool:
+        """Check if a value exists in the storage backend."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def list(self):
+        """List all keys in the storage backend."""
+        raise NotImplementedError  # pragma: no cover

--- a/sweet_validation/tests/test_columns.py
+++ b/sweet_validation/tests/test_columns.py
@@ -1,8 +1,8 @@
 import pytest
 from frictionless.fields import IntegerField
 
-from sweet_validation.columns.columns import Column
 from sweet_validation.exceptions import ValidationError
+from sweet_validation.items import Column
 
 
 def test_init():


### PR DESCRIPTION
Setup abstract classes to define registry and storage.

A storage is an interface to storage operations that defines the basic interaction with the persistence layer.

Registries  enforce a metadata standard and use two storages, one for data and one for schemas. They provide the possibility to interact with stored data and schemes and get single columns. 